### PR TITLE
feat: Add software subgroups and new Unity projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,27 +162,69 @@
                 <div class="content-divider stagger-child"></div>
                 <div id="software-projects" class="stagger-child">
                     <h3 class="group-title translate-element" data-key="software-category-title">Программное обеспечение</h3>
-                    <div class="project-list">
-                        <article class="project-card">
-                            <div class="project-header">
-                                <div class="project-title-wrapper">
-                                    <h3 class="project-title translate-element"><a href="https://github.com/ineedmypills/OBS-Indicator" target="_blank" rel="noopener noreferrer" class="stretched-link">OBS Indicator</a></h3>
+
+                    <div class="subgroup">
+                        <h4 class="subgroup-title">OpenBroadcastSoftware</h4>
+                        <div class="project-list">
+                            <article class="project-card">
+                                <div class="project-header">
+                                    <div class="project-title-wrapper">
+                                        <h3 class="project-title translate-element"><a href="https://github.com/ineedmypills/OBS-Indicator" target="_blank" rel="noopener noreferrer" class="stretched-link">OBS Indicator</a></h3>
+                                    </div>
+                                    <p class="project-desc translate-element" data-key="obs-desc">Компактный экранный индикатор для записи и буфера повтора в OBS Studio</p>
                                 </div>
-                                <p class="project-desc translate-element" data-key="obs-desc">Компактный экранный индикатор для записи и буфера повтора в OBS Studio</p>
-                            </div>
-                            <div class="card-footer">
-                                <div class="footer-group-left">
-                                    <div class="tech-badge python-tech">
-                                        <span class="material-icons-outlined" aria-hidden="true">code</span>
-                                        Python
+                                <div class="card-footer">
+                                    <div class="footer-group-left">
+                                        <div class="tech-badge python-tech">
+                                            <span class="material-icons-outlined" aria-hidden="true">code</span>
+                                            Python
+                                        </div>
+                                    </div>
+                                    <div class="status-badge status-badge--completed">
+                                        <span class="material-icons-outlined" aria-hidden="true">check</span>
+                                        <span class="translate-element" data-key="completed">Завершенный проект</span>
                                     </div>
                                 </div>
-                                <div class="status-badge status-badge--completed">
-                                    <span class="material-icons-outlined" aria-hidden="true">check</span>
-                                    <span class="translate-element" data-key="completed">Завершенный проект</span>
+                            </article>
+                        </div>
+                    </div>
+
+                    <div class="subgroup">
+                        <h4 class="subgroup-title">Unity Engine</h4>
+                        <div class="project-list">
+                            <article class="project-card">
+                                <div class="project-header">
+                                    <div class="project-title-wrapper">
+                                        <h3 class="project-title translate-element"><a href="https://github.com/ineedmypills/UnityCensorEffect" target="_blank" rel="noopener noreferrer" class="stretched-link">Unity Censor Effect</a></h3>
+                                    </div>
+                                    <p class="project-desc translate-element" data-key="censor-effect-desc">Эффект постобработки для цензурирования объектов на определённом слое с помощью пикселизации</p>
                                 </div>
-                            </div>
-                        </article>
+                                <div class="card-footer">
+                                    <div class="footer-group-left">
+                                    </div>
+                                    <div class="status-badge status-badge--completed">
+                                        <span class="material-icons-outlined" aria-hidden="true">check</span>
+                                        <span class="translate-element" data-key="completed">Завершенный проект</span>
+                                    </div>
+                                </div>
+                            </article>
+                            <article class="project-card">
+                                <div class="project-header">
+                                    <div class="project-title-wrapper">
+                                        <h3 class="project-title translate-element"><a href="https://github.com/ineedmypills/UnitySceneInspector" target="_blank" rel="noopener noreferrer" class="stretched-link">Unity Scene Inspector</a></h3>
+                                    </div>
+                                    <p class="project-desc translate-element" data-key="scene-inspector-desc">Расширение для тулбара Unity с утилитами для управления сценами</p>
+                                </div>
+                                <div class="card-footer">
+                                    <div class="footer-group-left">
+                                    </div>
+                                    <div class="status-badge status-badge--completed">
+                                        <span class="material-icons-outlined" aria-hidden="true">check</span>
+                                        <span class="translate-element" data-key="completed">Завершенный проект</span>
+                                    </div>
+                                </div>
+                            </article>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -593,6 +593,23 @@ a { text-decoration: none; color: inherit; }
     color: var(--text);
 }
 
+.subgroup {
+    margin-top: 10px;
+}
+
+.subgroup:first-of-type {
+    margin-top: 20px;
+}
+
+.subgroup-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 15px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--card-border);
+}
+
 .tech-badge {
     padding: 5px 12px;
     border-radius: 20px;


### PR DESCRIPTION
- Restructures the 'Software' section to support subgroups.
- Creates 'OpenBroadcastSoftware' and 'Unity Engine' subgroups.
- Adds two new projects: 'Unity Censor Effect' and 'Unity Scene Inspector' to the 'Unity Engine' subgroup.
- Adds CSS styling for the new subgroup titles and containers to ensure a clean and organized layout.