### PR TITLE
Fix: Correct FIO display in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         </div>
 
         <h1 class="translate-element" id="main-header-title" data-key="main-title">ineedmypills</h1>
-        <p class="name-subtitle translate-element" id="main-header-name" data-key="full-name">Коктейльчик</p>
+        <p class="name-subtitle translate-element" id="main-header-name" data-key="full-name">Глухих Егор Алексеевич</p>
         <p class="subtitle translate-element" id="header-subtitle" data-key="specialist">Начинающий многосторонне развитый IT-"специалист"</p>
     </header>
 

--- a/server.log
+++ b/server.log
@@ -1,0 +1,9 @@
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /index.html HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /style.css HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /js/main.js HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /js/animations.js HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /js/state.js HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /js/share.js HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /js/ui.js HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:25] "GET /js/translations.js HTTP/1.1" 200 -
+127.0.0.1 - - [15/Aug/2025 15:57:26] "GET /index.html?show=header,alt_header,full_name,subtitle HTTP/1.1" 200 -


### PR DESCRIPTION
The user's full name (FIO) was incorrectly hardcoded to a nickname in `index.html`. This change corrects the initial text to display the proper FIO on page load.

This resolves the issue where the wrong name appeared, especially in environments where JavaScript might fail to load (e.g., local `file://` access). The original JavaScript logic for handling the alternative title was confirmed to be correct as per user feedback.